### PR TITLE
CI: Use ubuntu version with python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             python-version: "3.7"
           - os: ubuntu-latest
             python-version: "3.8"


### PR DESCRIPTION
Only fixes the run, the python 3.7 checks still fails due to some incompatible code (same error on Linux and Windows)